### PR TITLE
Switch to the 2.0.0-alpha.0 steamlocate release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,8 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "steamlocate"
-version = "1.0.1"
-source = "git+https://github.com/LovecraftianHorror/steamlocate-rs?branch=fully-switch-from-steamy-vdf#42be47af0ffae175dbe510bbe7dc6ccf2f742a9f"
+version = "2.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b1568c4a70a26c4373fe1131ffa4eff055459631b6e40c6bc118615f2d870c3"
 dependencies = [
  "dirs",
  "keyvalues-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ resolver = "2"
 
 
 [patch.crates-io]
-steamlocate = { git = "https://github.com/LovecraftianHorror/steamlocate-rs", branch = "fully-switch-from-steamy-vdf" } # Use this branch due to https://github.com/WilliamVenner/steamlocate-rs/issues/6
 #egui = { git = "https://github.com/emilk/egui", branch = "master" }
 #eframe = { git = "https://github.com/emilk/egui", branch = "master" }
 #egui_extras = { git = "https://github.com/emilk/egui", branch = "master" }

--- a/code/cli/Cargo.toml
+++ b/code/cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 secalc_core = { path = "../core", features = ["extract"] }
 structopt = "0.3"
-steamlocate = "1"
+steamlocate = "2.0.0-alpha.0"
 ron = "0.7"
 dotenv = "0.15"
 anyhow = "1"


### PR DESCRIPTION
The `fully-switch-from-steamy-vdf` branch changes are now released as an alpha