### PR TITLE
Update proc-macro2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
This updates `proc-macro2` to v1.0.60+ to fix the outdated dependency on the unstable `proc_macro_span_shrink` feature which was removed in rustc v1.73. 

Fixes #4